### PR TITLE
feat(plugin): allow the users to configure browser args (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ npm i --save-dev @neuralegion/cypress-har-generator
 Next, go to the cypress's directory and put this code is in your `cypress/plugins/index.js` file:
 
 ```js
-const { install } = require('@neuralegion/cypress-har-generator');
+const { install, ensureRequiredBrowserFlags } = require('@neuralegion/cypress-har-generator');
 
 module.exports = (on, config) => {
   install(on, config);
+  
+  on('before:browser:launch', (browser = {}, args) =>
+    ensureRequiredBrowserFlags(browser, args)
+  );
 };
 ```
 

--- a/example/cypress/plugins/index.js
+++ b/example/cypress/plugins/index.js
@@ -1,3 +1,9 @@
-const { install } = require('../../../dist');
+const { install, ensureRequiredBrowserFlags } = require('../../../dist');
 
-module.exports = (on, config) => install(on, config);
+module.exports = (on, config) => {
+  install(on, config);
+
+  on('before:browser:launch', (browser = {}, args) =>
+    ensureRequiredBrowserFlags(browser, args)
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ const DEFAULT_OPTIONS: PluginOptions = {
   stubPath: '/__cypress/xhrs/'
 };
 
+const plugin: Plugin = new Plugin(Logger.Instance, DEFAULT_OPTIONS);
+
 export function install(
   on: CypressCallback,
   config: Cypress.ConfigOptions
@@ -38,15 +40,18 @@ export function install(
     stubPath: env?.STUB_PATH ?? DEFAULT_OPTIONS.stubPath
   };
 
-  const plugin: Plugin = new Plugin(Logger.Instance, pluginOptions);
-
-  on('before:browser:launch', (browser: Cypress.Browser, args: string[]) =>
-    plugin.install(browser, args)
-  );
+  plugin.configure(pluginOptions);
 
   on('task', {
     saveHar: (): Promise<void> => plugin.saveHar(),
     recordHar: (): Promise<void> => plugin.recordHar(),
     removeHar: (): Promise<void> => plugin.removeHar()
   });
+}
+
+export function ensureRequiredBrowserFlags(
+  browser: Cypress.Browser,
+  args: string[]
+): string[] {
+  return plugin.ensureRequiredBrowserFlags(browser, args);
 }


### PR DESCRIPTION
BREAKING CHANGE: `install` function has been split in two parts: `install` and `ensureRequiredBrowserFlags`.

Before:

```js
const { install } = require('@neuralegion/cypress-har-generator');

module.exports = (on, config) => {
  install(on, config);
};
```

After:

```js
const { install, ensureRequiredBrowserFlags } = require('@neuralegion/cypress-har-generator');

module.exports = (on, config) => {
  install(on, config);

  on('before:browser:launch', (browser = {}, args) =>
    ensureRequiredBrowserFlags(browser, args)
  );
};
```

closes #13